### PR TITLE
Fix deterministic random seed

### DIFF
--- a/cli/benchmark.go
+++ b/cli/benchmark.go
@@ -20,7 +20,6 @@ package cli
 import (
 	"bytes"
 	"context"
-	"crypto/rand"
 	"encoding/binary"
 	"encoding/json"
 	"errors"
@@ -668,10 +667,9 @@ func pRandASCII(n int) string {
 	const asciiLetters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890"
 	// Use a single seed.
 	dst := make([]byte, n)
-	var seed [8]byte
+	seed := [8]byte{1, 2, 3, 4, 5, 6, 7, 8}
 
-	// Get something random
-	_, _ = rand.Read(seed[:])
+	// Use a fixed seed for deterministic output
 	rnd := binary.LittleEndian.Uint32(seed[0:4])
 	rnd2 := binary.LittleEndian.Uint32(seed[4:8])
 	for i := range dst {

--- a/cli/client.go
+++ b/cli/client.go
@@ -95,9 +95,9 @@ func newClient(ctx *cli.Context) func() (cl *minio.Client, done func()) {
 		running := make([]int, len(hosts))
 		lastFinished := make([]time.Time, len(hosts))
 		{
-			// Start with a random host
+			// Start with a random host using a fixed seed
 			now := time.Now()
-			off := rand.New(rand.NewSource(time.Now().UnixNano())).Intn(len(hosts))
+			off := rand.New(rand.NewSource(1)).Intn(len(hosts))
 			for i := range lastFinished {
 				lastFinished[i] = now.Add(time.Duration(i + off%len(hosts)))
 			}

--- a/cli/put.go
+++ b/cli/put.go
@@ -111,7 +111,7 @@ func putOpts(ctx *cli.Context) minio.PutObjectOptions {
 			}
 			var randN int
 			if _, err := fmt.Sscanf(value, "rand:%d", &randN); err == nil {
-				rng := rand.New(rand.NewSource(int64(rand.Uint64())))
+				rng := rand.New(rand.NewSource(1))
 				value = ""
 				for i := 0; i < randN; i++ {
 					value += string(metadataChars[rng.Int()%len(metadataChars)])

--- a/cli/sse.go
+++ b/cli/sse.go
@@ -18,8 +18,6 @@
 package cli
 
 import (
-	"crypto/rand"
-
 	"github.com/minio/cli"
 	"github.com/minio/minio-go/v7/pkg/encrypt"
 )
@@ -42,11 +40,10 @@ func newSSE(ctx *cli.Context) encrypt.ServerSide {
 	}
 
 	var key [32]byte
-	_, err := rand.Read(key[:])
-	if err != nil {
-		panic(err)
+	for i := range key {
+		key[i] = byte(i + 1)
 	}
-	sseKey, err = encrypt.NewSSEC(key[:])
+	sseKey, err := encrypt.NewSSEC(key[:])
 	if err != nil {
 		panic(err)
 	}

--- a/cli/zip.go
+++ b/cli/zip.go
@@ -19,7 +19,6 @@ package cli
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/minio/cli"
 	"github.com/minio/pkg/v3/console"
@@ -72,7 +71,7 @@ func mainZip(ctx *cli.Context) error {
 	b := bench.S3Zip{
 		Common:      getCommon(ctx, newGenSource(ctx, "obj.size")),
 		CreateFiles: ctx.Int("files"),
-		ZipObjName:  fmt.Sprintf("%d.zip", time.Now().UnixNano()),
+		ZipObjName:  fmt.Sprintf("%d.zip", 1),
 	}
 	b.Locking = true
 	return runBench(ctx, &b)

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -99,7 +99,7 @@ func (o *Object) setPrefix(opts Options) {
 		return
 	}
 	b := make([]byte, opts.randomPrefix)
-	rng := rand.New(rand.NewSource(int64(rand.Uint64())))
+	rng := rand.New(rand.NewSource(1))
 	randASCIIBytes(b, rng)
 	o.Prefix = path.Join(opts.customPrefix, string(b))
 }

--- a/pkg/generator/random.go
+++ b/pkg/generator/random.go
@@ -85,7 +85,7 @@ type randomSrc struct {
 }
 
 func newRandom(o Options) (Source, error) {
-	rndSrc := rand.NewSource(int64(rand.Uint64()))
+	rndSrc := rand.NewSource(1)
 	if o.random.seed != nil {
 		rndSrc = rand.NewSource(*o.random.seed)
 	}


### PR DESCRIPTION
## Summary
- fix deterministic random seed for object metadata and host selection
- remove runtime entropy use when generating SSE keys
- use fixed seed for prefix generation and object generator
- make ASCII helper deterministic
- remove unused imports

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68886316d7748324be9e934e2ac722cc